### PR TITLE
Added Tag array dependency to display tags

### DIFF
--- a/themes/nodebb-theme-persona/templates/recent.tpl
+++ b/themes/nodebb-theme-persona/templates/recent.tpl
@@ -16,26 +16,13 @@
                 <div class="alert alert-warning hide" id="new-topics-alert"></div>
             </a>
         </div>
-
-      
+        
     <div class="btn-group pull-right bottom-sheet">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-
-           
-
                 <span class="visible-sm-inline visible-md-inline visible-lg-inline">All Tags</span><span class="visible-xs-inline"><i class="fa fa-fw {selectedFilter.icon}"></i></span> <span class="caret"></span>
-
-                
-    
             </button>
-           
 
                <ul component="category/list" class="dropdown-menu category-dropdown-menu" role="menu">
-            
-                   
-                        
-                        
-                        
                         <div class="tags">
                             <!-- IF displayTagSearch -->
                             <!-- IF tags.length -->
@@ -64,24 +51,12 @@
                                 </div>
                             </div>
                         </div>
-                        
-
-                    
-                     
-                    
-                    
-
-                
 
     <li role="presentation" class="category" data-all="all">
          <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
          </li>
 </ul> 
-            
-    
-
 </div>
-
 
         <div class="btn-group pull-right">
         <!-- IMPORT partials/category/tools.tpl -->
@@ -100,9 +75,6 @@
                 </li>
                 {{{end}}}
             </ul>
-
-            
-
         </div>
     </div>
 

--- a/themes/nodebb-theme-persona/templates/recent.tpl
+++ b/themes/nodebb-theme-persona/templates/recent.tpl
@@ -23,7 +23,7 @@
 
            
 
-                <span class="visible-sm-inline visible-md-inline visible-lg-inline">{selectedFilter.name}</span><span class="visible-xs-inline"><i class="fa fa-fw {selectedFilter.icon}"></i></span> <span class="caret"></span>
+                <span class="visible-sm-inline visible-md-inline visible-lg-inline">All Tags</span><span class="visible-xs-inline"><i class="fa fa-fw {selectedFilter.icon}"></i></span> <span class="caret"></span>
 
                 
     
@@ -44,13 +44,21 @@
             </ul> 
 
                <ul component="category/list" class="dropdown-menu category-dropdown-menu" role="menu">
+                <div class="category row">
+                    <div class="col-md-12 clearfix tag-list" data-nextstart="{nextStart}">
+                        <!-- IMPORT tags.tpl -->
+                    </div>
+                     
+                    
+                    
+
+                </div>
+
     <li role="presentation" class="category" data-all="all">
          <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
-    {{{each categoryItems}}}
-    <li role="presentation" class="category {{{ if ../disabledClass }}}disabled{{{ end }}}" data-cid="{../cid}" data-parent-cid="{../parentCid}" data-name="{../name}">
-        <a role="menu-item" href="#">{../level}<i component="category/select/icon" class="fa fa-fw fa-check {{{ if !../selected }}}invisible{{{ end }}}"></i><span component="category-markup" style="{{{ if ../match }}}font-weight: bold;{{{end}}}">{{{ if ../icon }}}<span class="fa-stack" style="{function.generateCategoryBackground}"><i class="fa fa-fw fa-stack-1x {../icon}" style="color: {../color};"></i></span>{{{ end }}} {../name}</span></a>
-    </li>
-    {{{end}}}
+         {{{ each ../topic.tags }}}
+         <a href="{config.relative_path}/tags/{topic.tags.valueEncoded}"><span class="tag tag-item tag-class-{topic.tags.class}">{topic.tags.valueEscaped}</span></a>
+         {{{ end }}}
 </ul> 
             
     

--- a/themes/nodebb-theme-persona/templates/recent.tpl
+++ b/themes/nodebb-theme-persona/templates/recent.tpl
@@ -17,6 +17,47 @@
             </a>
         </div>
 
+      
+    <div class="btn-group pull-right bottom-sheet">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+
+           
+
+                <span class="visible-sm-inline visible-md-inline visible-lg-inline">{selectedFilter.name}</span><span class="visible-xs-inline"><i class="fa fa-fw {selectedFilter.icon}"></i></span> <span class="caret"></span>
+
+                
+    
+            </button>
+           <ul class="dropdown-menu" role="menu">
+             
+
+                
+    {{{each tags}}}
+     <li role="presentation" class="category {{{if filters.selected}}}selected{{{end}}}">
+       <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
+       </li>
+    {{{end}}}
+
+
+             
+
+            </ul> 
+
+               <ul component="category/list" class="dropdown-menu category-dropdown-menu" role="menu">
+    <li role="presentation" class="category" data-all="all">
+         <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
+    {{{each categoryItems}}}
+    <li role="presentation" class="category {{{ if ../disabledClass }}}disabled{{{ end }}}" data-cid="{../cid}" data-parent-cid="{../parentCid}" data-name="{../name}">
+        <a role="menu-item" href="#">{../level}<i component="category/select/icon" class="fa fa-fw fa-check {{{ if !../selected }}}invisible{{{ end }}}"></i><span component="category-markup" style="{{{ if ../match }}}font-weight: bold;{{{end}}}">{{{ if ../icon }}}<span class="fa-stack" style="{function.generateCategoryBackground}"><i class="fa fa-fw fa-stack-1x {../icon}" style="color: {../color};"></i></span>{{{ end }}} {../name}</span></a>
+    </li>
+    {{{end}}}
+</ul> 
+            
+    
+
+</div>
+
+
         <div class="btn-group pull-right">
         <!-- IMPORT partials/category/tools.tpl -->
         </div>
@@ -34,6 +75,9 @@
                 </li>
                 {{{end}}}
             </ul>
+
+            
+
         </div>
     </div>
 

--- a/themes/nodebb-theme-persona/templates/recent.tpl
+++ b/themes/nodebb-theme-persona/templates/recent.tpl
@@ -28,37 +28,54 @@
                 
     
             </button>
-           <ul class="dropdown-menu" role="menu">
-             
-
-                
-    {{{each tags}}}
-     <li role="presentation" class="category {{{if filters.selected}}}selected{{{end}}}">
-       <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
-       </li>
-    {{{end}}}
-
-
-             
-
-            </ul> 
+           
 
                <ul component="category/list" class="dropdown-menu category-dropdown-menu" role="menu">
-                <div class="category row">
-                    <div class="col-md-12 clearfix tag-list" data-nextstart="{nextStart}">
-                        <!-- IMPORT tags.tpl -->
-                    </div>
+            
+                   
+                        
+                        
+                        
+                        <div class="tags">
+                            <!-- IF displayTagSearch -->
+                            <!-- IF tags.length -->
+                            <div class="row">
+                                <div class="col-lg-12">
+                                    <div class="input-group">
+                                        <input type="text" class="form-control" placeholder="[[global:search]]" id="tag-search">
+                                        <span class="input-group-addon search-button"><i class="fa fa-search"></i></span>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- ENDIF tags.length -->
+                            <!-- ENDIF displayTagSearch -->
+                        
+                            <!-- IF !tags.length -->
+                            <div class="alert alert-warning">[[tags:no_tags]]</div>
+                            <!-- ENDIF !tags.length -->
+                        
+                            <div class="category row">
+                                <div class="col-md-12 clearfix tag-list" data-nextstart="{nextStart}">
+                                    {{{each tags}}}
+                                    <h3 class="pull-left tag-container">
+                                        <a href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
+                                    </h3>
+                                    {{{end}}}
+                                </div>
+                            </div>
+                        </div>
+                        
+
+                    
                      
                     
                     
 
-                </div>
+                
 
     <li role="presentation" class="category" data-all="all">
          <a role="menu-item" href="{config.relative_path}/tags/{tags.valueEncoded}" data-value="{tags.valueEscaped}"><span class="tag-item tag-class-{tags.class}" data-tag="{tags.valueEscaped}">{tags.valueEscaped}</span><span class="tag-topic-count human-readable-number" title="{tags.score}">{tags.score}</span></a>
-         {{{ each ../topic.tags }}}
-         <a href="{config.relative_path}/tags/{topic.tags.valueEncoded}"><span class="tag tag-item tag-class-{topic.tags.class}">{topic.tags.valueEscaped}</span></a>
-         {{{ end }}}
+         </li>
 </ul> 
             
     


### PR DESCRIPTION
- Building off of the creation of the tag filtering button from US#1 in Sprint 1 in 'recent.tpl':

- Removed the breadcrumbs that previously showed when clicking the button to open tag filter dropdown menu

- Dropdown will show 'no tags' if no tags have been created, however, it still displays even when the Tag array should not be empty

- Changed button label to say 'All Tags'